### PR TITLE
[show][config][plugin] add processing of ModuleNotFoundError with log_warning

### DIFF
--- a/tests/test_util_base.py
+++ b/tests/test_util_base.py
@@ -1,0 +1,31 @@
+from unittest.mock import patch, MagicMock
+from utilities_common.util_base import UtilHelper
+
+
+@patch("pkgutil.iter_modules")
+@patch("utilities_common.util_base.log.log_error")
+@patch("utilities_common.util_base.log.log_warning")
+def test_load_plugins_exceptions_logs(mock_log_warning, mock_log_error, mock_iter_modules):
+    NON_EXISTENT_MODULE_NAME = "non-existent-module"
+    FAILED_TO_IMPORT_MESSAGE = f"failed to import plugin {NON_EXISTENT_MODULE_NAME}"
+    COMMON_EXCEPTION_MESSAGE = "Common exception"
+
+    mock_iter_modules.return_value = [(None, NON_EXISTENT_MODULE_NAME, False)]
+    plugins_namespace = MagicMock()
+    plugins_namespace.__path__ = "some_path"
+    plugins_namespace.__name__ = "some_name"
+
+    # Assetion for ModuleNotFoundError
+    list(UtilHelper().load_plugins(plugins_namespace))
+    mock_log_warning.assert_called_once_with(
+        f"{FAILED_TO_IMPORT_MESSAGE}: No module named '{NON_EXISTENT_MODULE_NAME}'",
+        also_print_to_console=True
+    )
+
+    # Assertion for Exception
+    with patch("importlib.import_module", side_effect=Exception(COMMON_EXCEPTION_MESSAGE)):
+        list(UtilHelper().load_plugins(plugins_namespace))
+    mock_log_error.assert_called_once_with(
+        f"{FAILED_TO_IMPORT_MESSAGE}: {COMMON_EXCEPTION_MESSAGE}",
+        also_print_to_console=True
+    )

--- a/utilities_common/util_base.py
+++ b/utilities_common/util_base.py
@@ -29,6 +29,12 @@ class UtilHelper(object):
             log.log_debug('importing plugin: {}'.format(module_name))
             try:
                 module = importlib.import_module(module_name)
+
+            except ModuleNotFoundError as err:
+                log.log_warning('failed to import plugin {}: {}'.format(module_name, err),
+                                also_print_to_console=True)
+                continue
+
             except Exception as err:
                 log.log_error('failed to import plugin {}: {}'.format(module_name, err),
                               also_print_to_console=True)


### PR DESCRIPTION
There is the case of rare situation of race condition when plugin script file is removed right before the stage of its load via cli (e.g. in case of dynamic removing with app extensions). This situation has no impact but generate additional error messages to syslog

#### What I did
Add separate processing ModuleNotFoundError with log_warning messages to avoid excess ERR printing

#### How to verify it
It happens very rarely in nature but you can just try to remove plugin script manually right before its loading stage. I used this changes on top of my commit for testing:
```
diff --git a/utilities_common/util_base.py b/utilities_common/util_base.py
index 95098b7..c808b0a 100644
--- a/utilities_common/util_base.py
+++ b/utilities_common/util_base.py
@@ -2,6 +2,8 @@ import os
 import pkgutil
 import importlib

+import subprocess
+
 from sonic_py_common import logger

 # Constants ====================================================================
@@ -11,6 +13,7 @@ PDDF_SUPPORT_FILE = '/usr/share/sonic/platform/pddf_support'

 log = logger.Logger()

+plugin_path = "/usr/local/lib/python3.11/dist-packages/show/plugins/dhcp-relay.py"

 class UtilHelper(object):
     def __init__(self):
@@ -28,11 +31,15 @@ class UtilHelper(object):
                 continue
             log.log_debug('importing plugin: {}'.format(module_name))
             try:
+                if module_name == "show.plugins.dhcp-relay":
+                    subprocess.run(['mv', plugin_path, '/root/' ])
                 module = importlib.import_module(module_name)

             except ModuleNotFoundError as err:
                 log.log_warning('failed to import plugin {}: {}'.format(module_name, err),
                               also_print_to_console=True)
+                if module_name == "show.plugins.dhcp-relay":
+                    subprocess.run(['mv', '/root/dhcp-relay.py', plugin_path ])
                 continue

             except Exception as err:

```

